### PR TITLE
부득이한 경우 pdflatex 을 사용할 수 있게 함

### DIFF
--- a/gshs_thesis_certified-adv/gshs_thesis.cls
+++ b/gshs_thesis_certified-adv/gshs_thesis.cls
@@ -7,7 +7,15 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \ProvidesClass{gshs_thesis}
+
+\usepackage{ifxetex} % 부득이하게 pdflatex을 사용해도 문제가 없도록 함
+
+\ifxetex
 \LoadClass[11pt]{article}
+\else
+\usepackage[nonfrench]{kotex}
+\LoadClass[pdftex, 11pt]{article}
+\fi 
 
 \usepackage{geometry}
 \usepackage{amssymb}
@@ -21,8 +29,13 @@
 \usepackage{cite}   % citation [1,2,3] --> [1-3]
 \usepackage{tocloft}
 \usepackage[toc,page]{appendix}
-%\usepackage[T1]{fontenc}   % To use Times New Roman
-%\usepackage[utf8]{inputenc}% To use Times New Roman
+
+\ifxetex
+\else
+\usepackage[T1]{fontenc}   % To use Times New Roman
+\usepackage[utf8]{inputenc}% To use Times New Roman
+\fi
+
 \usepackage{mathptmx}      % To use Times New Roman
 \usepackage{array}
 \usepackage{setspace}
@@ -391,6 +404,8 @@
 {\end{alwayssingle}}
 
 
+
+\ifxetex
 %한글 사용 옵션
 \RequirePackage{xetexko}
 \setmainfont[Ligatures=TeX]{Times New Roman}
@@ -398,4 +413,5 @@
 	ItalicFont=*,ItalicFeatures=FakeSlant]{Batang}
 \disablecjksymbolspacing
 \nonfrenchspacing
-
+\else
+\fi

--- a/gshs_thesis_certified-adv/gshs_thesis_14XXX_main.tex
+++ b/gshs_thesis_certified-adv/gshs_thesis_14XXX_main.tex
@@ -1,4 +1,5 @@
 % !TeX program = xelatex
+%% 부득이하게 pdflatex을 사용해야 할 경우 위의 magic comment를 제거하십시오.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%  LaTeX format of the thesis of the Gyeonggi Science High School   %%%


### PR DESCRIPTION
본 adv ver. 양식을 그대로 pdflatex 으로 조판하면 문제점이 생겼었습니다. svg라는 패키지를 사용해야 하는 등 부득이하게 pdflatex을 사용해야 할 수 있으므로, ifxetex 문을 통해 사용중인 엔진을 인식하고 그에 따라 맞는 코드를 포함시키게 하였습니다. (여기에서 '부득이하게' pdflatex을 사용한다 함은 바탕 글꼴을 포기하고 나눔명조를 사용한다는 것을 뜻합니다.)

참고로 ifxetex 의 사용법은, 문서에 따르면 다음과 같습니다.
`\ifxetex`
`Material for XeTeX`
`\else`
`Material not for XeTeX`
`\fi`

TeXlive 2016 기준으로 정상 작동함이 확인되었습니다.
