### PR TITLE
gshs_thesis(-adv): Fix section numbering

### DIFF
--- a/gshs_thesis-adv/gshs_thesis.cls
+++ b/gshs_thesis-adv/gshs_thesis.cls
@@ -53,6 +53,8 @@
 \apptocmd{\thebibliography}{\setlength{\itemsep}{0pt}}{}{}
 %\setstretch{1.5}
 
+\renewcommand{\thesection}{\Roman{section}}
+
 \renewcommand{\thefootnote}{\fnsymbol{footnote}} 
 % 주석 번호와 참고문헌 번호의 혼동을 막기 위해 arabic 대신 fnsymbol 사용(asterisk, dagger, double dagger, ...)
 
@@ -342,7 +344,7 @@
 \titleformat{\subsection}[hang]
 {\normalfont\fontsize{16}{16}\selectfont\bfseries}{\Roman{section}.\arabic{subsection}}{1em}{}
 \titleformat{\subsubsection}[hang]
-{\normalfont\fontsize{14}{14}\selectfont}{\arabic{section}.\Roman{subsection}.\arabic{subsubsection}}{1em}{}
+{\normalfont\fontsize{14}{14}\selectfont}{\Roman{section}.\arabic{subsection}.\arabic{subsubsection}}{1em}{}
 \titleformat{\paragraph}[hang]
 {\normalfont\fontsize{12}{12}\selectfont\it}{}{1em}{}
 

--- a/gshs_thesis/gshs_thesis.cls
+++ b/gshs_thesis/gshs_thesis.cls
@@ -37,6 +37,8 @@
 \apptocmd{\thebibliography}{\setlength{\itemsep}{0pt}}{}{}
 %\setstretch{1.5}
 
+\renewcommand{\thesection}{\Roman{section}}
+
 \renewcommand{\thefootnote}{\fnsymbol{footnote}} 
 % 주석 번호와 참고문헌 번호의 혼동을 막기 위해 arabic 대신 fnsymbol 사용(asterisk, dagger, double dagger, ...)
 
@@ -332,9 +334,9 @@
 \titleformat{\section}[hang]
 {\normalfont\fontsize{21}{21}\selectfont\bfseries}{\Roman{section}.}{1em}{}
 \titleformat{\subsection}[hang]
-{\normalfont\fontsize{16}{16}\selectfont\bfseries}{\arabic{section}.\arabic{subsection}}{1em}{}
+{\normalfont\fontsize{16}{16}\selectfont\bfseries}{\Roman{section}.\arabic{subsection}}{1em}{}
 \titleformat{\subsubsection}[hang]
-{\normalfont\fontsize{14}{14}\selectfont}{\arabic{section}.\arabic{subsection}.\arabic{subsubsection}}{1em}{}
+{\normalfont\fontsize{14}{14}\selectfont}{\Roman{section}.\arabic{subsection}.\arabic{subsubsection}}{1em}{}
 \titleformat{\paragraph}[hang]
 {\normalfont\fontsize{12}{12}\selectfont\it}{}{1em}{}
 


### PR DESCRIPTION
박기현 선생님(@guitar79)의 제보를 받고 졸업논문 양식을 검토한 결과 몇 가지 문제가 발견되어 수정하였습니다.
# 수정 사항

- Table of Contents에 section 번호가 로마 숫자가 아닌 아라비아 숫자로 나오는 현상 수정
- adv 양식에서 subsubsection 번호가 I.1.1이 아닌 1.I.1처럼 나오는 현상 수정
- gshs_thesis에도 동일한 번호 양식 적용