### PR TITLE
Gshs thesis margin and xelatex

### DIFF
--- a/gshs_thesis/gshs_thesis.cls
+++ b/gshs_thesis/gshs_thesis.cls
@@ -10,8 +10,9 @@
 %% 한글, 영어 날짜 양식을 하나로 통합
 
 \ProvidesClass{gshs_thesis}
-\LoadClass[pdftex, a4paper]{article}
+\LoadClass[pdftex, 11pt]{article}
 
+\usepackage[tmargin=25mm,bmargin=30mm,lmargin=25mm,rmargin=25mm]{geometry}
 \usepackage{amssymb}
 \usepackage{amsmath}
 \usepackage{graphicx}
@@ -42,17 +43,17 @@
 
 \setlength{\hoffset}{0pt}
 \setlength{\voffset}{0pt}
-\setlength{\paperwidth}{597pt}
-\setlength{\paperheight}{845pt}
-\setlength{\oddsidemargin}{42pt}
-\setlength{\evensidemargin}{42pt}
+\setlength{\paperwidth}{195mm}
+\setlength{\paperheight}{255mm}
+\setlength{\oddsidemargin}{0mm}
+\setlength{\evensidemargin}{0mm}
 \setlength{\topmargin}{0pt}
 \setlength{\headheight}{0pt}
-\setlength{\headsep}{25pt}
-\setlength{\textheight}{569pt}
-\setlength{\textwidth}{384pt}
-\setlength{\marginparsep}{10pt}
-\setlength{\marginparwidth}{35pt}
+\setlength{\headsep}{0pt}
+\setlength{\textheight}{200mm}
+\setlength{\textwidth}{145mm}
+\setlength{\marginparsep}{0mm}
+\setlength{\marginparwidth}{0mm}
 \setlength{\footskip}{56pt}
 
 

--- a/gshs_thesis/gshs_thesis.cls
+++ b/gshs_thesis/gshs_thesis.cls
@@ -10,7 +10,15 @@
 %% 한글, 영어 날짜 양식을 하나로 통합
 
 \ProvidesClass{gshs_thesis}
+
+\usepackage{ifxetex} % 부득이하게 pdflatex을 사용해도 문제가 없도록 함
+
+\ifxetex
+\LoadClass[11pt]{article}
+\else
+\usepackage[nonfrench]{kotex}
 \LoadClass[pdftex, 11pt]{article}
+\fi
 
 \usepackage[tmargin=25mm,bmargin=30mm,lmargin=25mm,rmargin=25mm]{geometry}
 \usepackage{amssymb}
@@ -393,3 +401,14 @@
 \vspace{0.5cm}
 }
 {\end{alwayssingle}}
+
+\ifxetex
+%한글 사용 옵션
+\RequirePackage{xetexko}
+\setmainfont[Ligatures=TeX]{Times New Roman}
+\setmainhangulfont[BoldFont=*,BoldFeatures=FakeBold,%
+    ItalicFont=*,ItalicFeatures=FakeSlant]{Batang}
+\disablecjksymbolspacing
+\nonfrenchspacing
+\else
+\fi

--- a/gshs_thesis/gshs_thesis.tex
+++ b/gshs_thesis/gshs_thesis.tex
@@ -1,3 +1,6 @@
+% !TeX program = xelatex
+%% 부득이하게 pdflatex을 사용해야 할 경우 위의 magic comment를 제거하십시오.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%  LaTeX document class of the thesis of the Gyeonggi Science High School   %%%
 %%%  Last edition 2015.11.13 by Chinook Mok                                   %%%
@@ -7,7 +10,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \documentclass[twoside,11pt]{gshs_thesis}
-\RequirePackage[nonfrench]{kotex}
 % 이곳에 필요한 별도의 패키지들을 적어넣으시오.
 %\usepackage{...}
 \usepackage{verbatim} % for commment, verbatim environment
@@ -130,11 +132,9 @@
 %----------------------------------------------
 %     List of Figures/Tables (자동 작성됨)
 %----------------------------------------------
-\cleardoublepage
 \clearpage
 \listoffigures	% 그림 목록과 캡션을 출력한다. 만약 논문에 그림이 없다면 이 줄의 맨 앞에 %기호를 넣어서 코멘트 처리한다.
 
-\cleardoublepage
 \clearpage
 \listoftables  % 표 목록과 캡션을 출력한다. 만약 논문에 표가 없다면 이 줄의 맨 앞에 %기호를 넣어서 코멘트 처리한다.
 
@@ -142,7 +142,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%% Main Document %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\cleardoublepage
 \clearpage
 \renewcommand{\thepage}{\arabic{page}}
 \setcounter{page}{1}

--- a/gshs_thesis/gshs_thesis.tex
+++ b/gshs_thesis/gshs_thesis.tex
@@ -3,7 +3,7 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%  LaTeX document class of the thesis of the Gyeonggi Science High School   %%%
-%%%  Last edition 2015.11.13 by Chinook Mok                                   %%%
+%%%  Last edition 2020.02.22 by Jaeyong Sung                                  %%%
 %%%  Continously being modified by gshslatexintro after 2016.02.02.           %%%
 %%%  Check the latest version at : latex.gs.hs.kr                             %%%
 %%%  Also refer to https://www.facebook.com/gshstexsociety                    %%%
@@ -43,7 +43,7 @@
 \korname{홍 길 동} %저자 이름을 한글로 입력하시오 (글자 사이 띄어쓰기)
 \engname{Hong, Gil-Dong} %저자 이름을 영어로 입력하시오 (family name, personal name)
 \chnname{洪 吉 東} %저자 이름을 한자로 입력하시오 (글자 사이 띄어쓰기)
-\studid{13201} %학번을 입력하시오
+\studid{18000} %학번을 입력하시오
 
 %------------------------------------------------------------------------
 %                  심사위원과 논문 승인 날짜를 입력하시오
@@ -52,10 +52,10 @@
 \judgeone{박 교 수} %심사위원장
 \judgetwo{김 대 감}   %심사위원1
 \judgethree{목 진 욱} %심사위원2(지도교사)
-\degreeyear{2016}   %졸업 년도
+\degreeyear{2021}   %졸업 년도
 %\degreedate{2015}{11}{13} %논문 승인 날짜 양식
-\degreedate{2016. 11. 21} %논문 승인 날짜 양식1
-\degreedatekor{2016년 11월 21일} %논문 승인 날짜 양식2
+\degreedate{2020. 11. 21} %논문 승인 날짜 양식1
+\degreedatekor{2020년 11월 21일} %논문 승인 날짜 양식2
 
 %------------------------------------------------------------------------
 %                  논문제출 전 체크리스트를 확인하시오

--- a/gshs_thesis/gshs_thesis.tex
+++ b/gshs_thesis/gshs_thesis.tex
@@ -9,7 +9,7 @@
 %%%  Also refer to https://www.facebook.com/gshstexsociety                    %%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\documentclass[twoside,11pt]{gshs_thesis}
+\documentclass{gshs_thesis}
 % 이곳에 필요한 별도의 패키지들을 적어넣으시오.
 %\usepackage{...}
 \usepackage{verbatim} % for commment, verbatim environment
@@ -132,9 +132,11 @@
 %----------------------------------------------
 %     List of Figures/Tables (자동 작성됨)
 %----------------------------------------------
+\cleardoublepage
 \clearpage
 \listoffigures	% 그림 목록과 캡션을 출력한다. 만약 논문에 그림이 없다면 이 줄의 맨 앞에 %기호를 넣어서 코멘트 처리한다.
 
+\cleardoublepage
 \clearpage
 \listoftables  % 표 목록과 캡션을 출력한다. 만약 논문에 표가 없다면 이 줄의 맨 앞에 %기호를 넣어서 코멘트 처리한다.
 
@@ -142,6 +144,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%% Main Document %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\cleardoublepage
 \clearpage
 \renewcommand{\thepage}{\arabic{page}}
 \setcounter{page}{1}


### PR DESCRIPTION
**이 commit을 통한 변화 내용 :**

1. gshs-thesis의 여백을 word/hwp 양식에 맞게 수정
2. xelatex로 컴파일할 때 생기던 koxetex관련 오류 수정

**컴파일 환경**
(잘 모르실 경우 입력하지 않으셔도 됩니다.)

- 제가 사용한 TeXlive 버전은 : 2017 (년도 입력) 입니다.
- 사용한 엔진은 xelatex, pdflatex입니다.

현재 Ubuntu에서 컴파일해 보았지만, 다른 운영체제에서 제대로 동작하는 지 확인이 필요합니다.
위와 같은 내용의 코드 수정사항을 검토해 주시고, 시험가동 후 문제가 없을 경우 merge 해주시길 바랍니다.