### PR TITLE
Fixed issue #25

### DIFF
--- a/gshs_thesis-adv/gshs_thesis.bst
+++ b/gshs_thesis-adv/gshs_thesis.bst
@@ -571,7 +571,7 @@ FUNCTION {format.pages}
 FUNCTION {format.vol.num.pages}
 { number empty$
     { volume empty$
-       'skip$
+       { "" }
        { "{\em " volume * "}" * }
 %	   { "\underline{" volume * "}" * }
       if$


### PR DESCRIPTION
**이 commit을 통한 변화 내용 :**

기존 코드는 `gshs_thesis.bst`의 `format.num.vol.pages` 함수에서 `number`와 `volume` 모두 비어 있을 때 `skip$`을 호출했는데,
이렇게 하면 이후의 `output`함수에서 스택이 비어 있다는 오류가 생깁니다.
`""`를 푸시하는 코드로 변경했습니다.

**컴파일 환경**

- 제가 사용한 TeXlive 버전은 : 2019 입니다.
- 사용한 엔진은 xelatex입니다.
